### PR TITLE
0.28 - User messaging

### DIFF
--- a/django_twilio_2fa/app_settings.py
+++ b/django_twilio_2fa/app_settings.py
@@ -176,6 +176,19 @@ class Conf:
         The [error code](errors.md) is sent and the string or gettext_lazy 
         """
     )
+    message_displays = Setting(
+        "message_display",
+        must_be_callable=True,
+        cb_kwargs_required=["code"],
+        description="""
+        Allows for overriding non-error messages displayed to user.
+        
+        The message code is sent and the string or gettext_lazy instance is returned.
+        
+        Message codes and default messages:
+         * `verification_resent` - Verification has been resent
+        """
+    )
     allow_userless = Setting(
         "allow_userless",
         default=False,

--- a/django_twilio_2fa/errors.py
+++ b/django_twilio_2fa/errors.py
@@ -156,7 +156,7 @@ class MobileNumberRequired(Error):
 
 class SendCooldown(Error):
     code = "resend_cooldown"
-    display = _("Please wait before resending your verification")
+    display = _("Please wait at least {can_resend_in} seconds before resending your verification")
 
 
 class EmailNotSet(Error):

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -27,7 +27,7 @@ When using the API endpoints, errors are returned as a JSON object:
 
 * **Error code:** `change_not_allowed`
 * **Display for user:** `You cannot change your {field_display}`
-* **Status Code:** `500`
+* **Status Code:** `400`
 * **Should block further attempts?** No
 
 
@@ -35,7 +35,7 @@ When using the API endpoints, errors are returned as a JSON object:
 
 * **Error code:** `email_not_set`
 * **Display for user:** `An e-mail address is not set for your account.`
-* **Status Code:** `500`
+* **Status Code:** `400`
 * **Should block further attempts?** No
 
 
@@ -43,7 +43,7 @@ When using the API endpoints, errors are returned as a JSON object:
 
 * **Error code:** `twilio_error_{twilio_error}`
 * **Display for user:** `Unable to verify at this time`
-* **Status Code:** `500`
+* **Status Code:** `400`
 * **Should block further attempts?** No
 
 
@@ -123,7 +123,7 @@ When using the API endpoints, errors are returned as a JSON object:
 
 * **Error code:** `no_method_available`
 * **Display for user:** `No method available for verification`
-* **Status Code:** `500`
+* **Status Code:** `400`
 * **Should block further attempts?** Yes
 
 
@@ -139,7 +139,7 @@ When using the API endpoints, errors are returned as a JSON object:
 
 * **Error code:** `phone_not_set`
 * **Display for user:** `A phone number is not set for your account.`
-* **Status Code:** `500`
+* **Status Code:** `400`
 * **Should block further attempts?** No
 
 
@@ -147,15 +147,15 @@ When using the API endpoints, errors are returned as a JSON object:
 
 * **Error code:** `registration_not_allowed`
 * **Display for user:** `You cannot set your 2FA {field_display}`
-* **Status Code:** `500`
+* **Status Code:** `400`
 * **Should block further attempts?** No
 
 
 ## `SendCooldown`
 
 * **Error code:** `resend_cooldown`
-* **Display for user:** `Please wait before resending your verification`
-* **Status Code:** `500`
+* **Display for user:** `Please wait at least {can_resend_in} seconds before resending your verification`
+* **Status Code:** `400`
 * **Should block further attempts?** No
 
 
@@ -171,7 +171,7 @@ When using the API endpoints, errors are returned as a JSON object:
 
 * **Error code:** `twilio_rate_limited`
 * **Display for user:** `Unable to verify at this time`
-* **Status Code:** `500`
+* **Status Code:** `400`
 * **Should block further attempts?** No
 
 
@@ -179,7 +179,7 @@ When using the API endpoints, errors are returned as a JSON object:
 
 * **Error code:** `unauthenticated_user_field_missing`
 * **Display for user:** `Unable to verify at this time`
-* **Status Code:** `500`
+* **Status Code:** `400`
 * **Should block further attempts?** No
 
 
@@ -219,7 +219,7 @@ When using the API endpoints, errors are returned as a JSON object:
 
 * **Error code:** `user_required`
 * **Display for user:** `A user is required for 2FA`
-* **Status Code:** `500`
+* **Status Code:** `400`
 * **Should block further attempts?** Yes
 
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -162,6 +162,22 @@ Maximum number of sends (configurable through Twilio)
 Defaults to: `5`
 
 
+### `MESSAGE_DISPLAY_CB`
+_This setting must be a callable._
+
+Allows for overriding non-error messages displayed to user.
+
+The message code is sent and the string or gettext_lazy instance is returned.
+
+Message codes and default messages:
+* `verification_resent` - Verification has been resent
+
+Defaults to: `None`
+
+If callable, the following kwargs are sent:
+ * `code`
+
+
 ### `METHOD_DETAILS`
 
 Allows overriding a verification method's details like icon and display text.
@@ -274,6 +290,15 @@ Defaults to: `None`
 
 If callable, the following kwargs are sent:
  * `user`
+
+
+### `TOKEN_LENGTH`
+
+The length of the token expected from the user.
+
+This is used for validation before sending to the verify API.Defaults to 6.
+
+Defaults to: `6`
 
 
 ### `UNAUTHENTICATED_QUERY_PARAM`

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-twilio-2fa
-version = 0.27
+version = 0.28
 author = Logan Bibby <lbibby@thesummitgrp.com>
 description = Django app for performing 2FA using Twilio Verify
 long_description = file: README.md


### PR DESCRIPTION
Added message_displays setting; fixed client.get_user() to allow request to be None; added client.get_message() to utilize message_displays; added can_resend_in to SendCooldown error instantiation; updated SendCooldown display to include can_resend_in; updated TwoFAStartView to catch errors and use the error's display for the user message and use client.get_message for non-error message; regenerated settings and error docs; version bump